### PR TITLE
Added setCurrencyCode to example in advanced guide

### DIFF
--- a/distributor-widget/advanced-guide.md
+++ b/distributor-widget/advanced-guide.md
@@ -24,6 +24,7 @@ function(distributor) {
     // Always available api calls
     // distributor.open();
     // distributor.setLanguageCode(languageCode);
+    // distributor.setCurrencyCode(currencyCode);
     // distributor.setStartDate(date);
     // distributor.setEndDate(date);
     // distributor.setVoucherCode(code);


### PR DESCRIPTION
The example didn't include `setCurrencyCode` which is supported - see https://mews-systems.gitbook.io/distributor-guide/distributor-widget/reference https://mews.slack.com/archives/CD8AHP1RP/p1568637415009700