### PR TITLE
Introduced Posting property

### DIFF
--- a/distributor-api-v1/operations.md
+++ b/distributor-api-v1/operations.md
@@ -382,6 +382,20 @@ If the hotel does not use any payment gateway, the value is null. If it does, th
 | `IncludedByDefault` | boolean | required | Indicates whether the product should be added to order by default. |
 | `AlwaysIncluded` | boolean | required | Indicates whether the product is always included \(= cannot be removed\). |
 | `Prices` | [CurrencyValues](operations.md#currencyvalues) | required | Price of the product. |
+| `Charging` | string [Product charging](operations.md#product-charging) | required | Charging of the product. |
+| `Posting` | string [Product posting](operations.md#product-posting) | required | Posting of the product. |
+
+#### Product charging
+
+* `Once`
+* `PerRoomNight`
+* `PerPersonNight`
+* `PerPerson`
+
+#### Product posting
+
+* `Once`
+* `Daily`
 
 #### CurrencyValues   <a id="currencyvalues"></a>
 

--- a/distributor-api-v1/operations.md
+++ b/distributor-api-v1/operations.md
@@ -90,6 +90,7 @@ Preferred initial call used to obtain all static data about distributor configur
                         "AlwaysIncluded":false,
                         "CategoryId":null,
                         "Charging":"Once",
+                        "Posting":"Once",
                         "Description": {
                             "en-US": "Continental breakfast served in the morning."
                         },
@@ -259,6 +260,7 @@ Alternative initial call used to obtain all static data about hotel relevant for
             },
             "RelativePrice": null,
             "Charging": "Once",
+            "Posting": "Once",
             "Ordering": 0
         }
     ],


### PR DESCRIPTION
Introduced product "Posting" property which contain 2 types (Once and Daily). Posting property will be a part of the Product response. 

The reason why this property was introduced is because until now, we've sent all the products together and posted them once (ex: 3x Breakfast). Now we will be posting these products daily (if the product was created with Posting daily option) meaning the response will contain one item for each day.

A sample response for the product part when calling `api/distributor/v1/configuration/get` endpoint:



                "Products":[
                    {
                        "AlwaysIncluded":false,
                        "CategoryId":null,
                        "Charging":"PerPerson",
                        "Posting": "Daily"
                        "Description": {
                            "en-US": "Continental breakfast served in the morning."
                        },
                        "Id": "1627aea5-8e0a-4371-9022-9b504344e724",
                        "ImageId": "1627aea5-8e0a-4371-9022-9b504344e724",
                        "IncludedByDefault":false,
                        "Ordering":0,
                        "Name": {
                            "en-US": "Breakfast"
                        },
                        "Prices": {
                            "EUR": 5,
                            "CZK": 150
                        }
                        "RelativePrice":null
                    }
                ],

