### PR TITLE
added ConfigurationId to reservationGroups create request

### DIFF
--- a/distributor-api-v1/operations.md
+++ b/distributor-api-v1/operations.md
@@ -843,7 +843,7 @@ Gives a pricing information for the given configuration.
 |  | Property | Type | Description |
 | :--- | :--- | :--- | :--- |
 | `Client` | string | required | Identification of the client as described in [Authorization](https://mews-systems.gitbook.io/distributor-guide/distributor-api-v1/authorization). |
-| `ConfigurationId` | string | optional | GUID of the used Distributor configuration |
+| `ConfigurationId` | string | optional | GUID of the used Distributor configuration. If not specified, the configuration id which is set as property/hotel default will be used. |
 | `HotelId` | string | required | Unique identifier of the hotel. |
 | `Customer` | [Customer](operations.md#customer) | required | Information about customer who creates the order. |
 | `Booker` | [Booker](operations.md#booker) | optional | Information about booker. |

--- a/distributor-api-v1/operations.md
+++ b/distributor-api-v1/operations.md
@@ -796,6 +796,7 @@ Gives a pricing information for the given configuration.
 ```javascript
 {
     "Client": "My Client 1.0.0",
+    "ConfigurationId": "5dfgaeb5-5848-81b3-40b7-d102e96kcf52",
     "HotelId": "3edbe1b4-6739-40b7-81b3-d369d9469c48",
     "Customer": {
         "Email": "hiro@snow.com",
@@ -842,6 +843,7 @@ Gives a pricing information for the given configuration.
 |  | Property | Type | Description |
 | :--- | :--- | :--- | :--- |
 | `Client` | string | required | Identification of the client as described in [Authorization](https://mews-systems.gitbook.io/distributor-guide/distributor-api-v1/authorization). |
+| `ConfigurationId` | string | optional | GUID of the used Distributor configuration |
 | `HotelId` | string | required | Unique identifier of the hotel. |
 | `Customer` | [Customer](operations.md#customer) | required | Information about customer who creates the order. |
 | `Booker` | [Booker](operations.md#booker) | optional | Information about booker. |


### PR DESCRIPTION
There was a missing parameter in documentation for `/api/distributor/v1/reservationGroups/create`

part of https://mews.myjetbrains.com/youtrack/issue/TDD-1685 , doesn't close the task