### PR TITLE
Fix gross value and net value description

### DIFF
--- a/distributor-api-v1/operations.md
+++ b/distributor-api-v1/operations.md
@@ -569,8 +569,8 @@ An object where name corresponds to ISO code and value represents a structure th
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| `GrossValue` | Number | An amount without taxes |
-| `NetValue` | Number | A net price + taxes |
+| `GrossValue` | Number | Net price + taxes |
+| `NetValue` | Number | Amount without taxes |
 | `TaxValues` | Collection of [TaxValue](operations.md#taxvalue)s | Tax values for the net value amount |
 
 #### TaxValue <a id="taxvalue"></a>


### PR DESCRIPTION
#### Changelog notes 

```
* Fixed description for `GrossValue` and `NetValue` fields in Ammount object
```

#### Check during review

- [x] JSON example extended.
  - [x] New properties are added to the correct place in the JSON.
- [x] New properties in the table are added to the correct place.
- [x] Correct formatting:
  - [x] Spacing is consistent between titles, sections, tables, ...
  - [x] Correct JSON format - indentation.
- [x] DateTime properties should always be defined in ISO format.
