### PR TITLE
docs(widget): Remove deprecation notice from Integration section

### DIFF
--- a/distributor-widget/changelog.md
+++ b/distributor-widget/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16.02.2021
+
+* Removed deprecation notice for no longer supported integrations which can be set up via [GTM integration](integrations.md#google-tag-manager). 
+
 ## 22.06.2020
 
 * Updated info about payment gateways and payment card storages. 

--- a/distributor-widget/integrations.md
+++ b/distributor-widget/integrations.md
@@ -1,21 +1,5 @@
 # Integrations
 
-> **Deprecation notice:** <a id="deprecated-options"></a>
->
-> The following widget configuration options are deprecated and will be removed from the distributor on the 30th of September 2019. Google tag manager is the de facto method for adding 3rd party tags and tracking services to the Distributor.
-> ```
-> facebookPixelId
-> hashEvents
-> analyticsTrackingId
-> gaTrackerName
-> ecommerce
-> ecommerceTrackerName
-> adwords
-> adwordsConversionId
-> adwordsConversionLabel
-> onBookingFinished
-> ```
-
 ## Google Tag Manager   <a id="google-tag-manager"></a>
 
 This guide assumes at least basic knowledge of [Google Tag Manager](https://www.google.com/analytics/tag-manager/) - how to create and publish a container, how to setup a triggers and custom events and how to connect them to a tags.


### PR DESCRIPTION
#### Changelog notes 

```
* Removed deprecation notice for integrations that can be set up via GTM integration
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
