### PR TITLE
fix(docs): removed dead link

### DIFF
--- a/distributor-widget/reference.md
+++ b/distributor-widget/reference.md
@@ -120,7 +120,7 @@ Sets Distributor to the`Rooms`step.
 
 #### showRates\(roomId\) <a id="showratesroomid"></a>
 
-* `roomId` Type: `string` - an ID of a room to be selected \(see[`rooms`](https://mewssystems.github.io/public/content/distributor/widget/reference.html#rooms)option for more details about those Ids\)
+* `roomId` Type: `string` - an ID of a room to be selected
 
 Sets Distributor to the third step \(`Rates`\) as if you selected a room on the second screen.
 


### PR DESCRIPTION
Removes dead link. Looks like it was never working and we have no section explaining room id more. And it now matches how other ids on this page are described.

#### Changelog notes 

```
* Removed dead link.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
