### PR TITLE
added documentation for initial occupancy deeplinks

### DIFF
--- a/distributor-standalone/changelog.md
+++ b/distributor-standalone/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 17.01.2021
+## 18.01.2021
 
 * Introduced new deeplinks `mewsAdultCount` and `mewsChildCount` to set initial occupancy.
 

--- a/distributor-standalone/changelog.md
+++ b/distributor-standalone/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 17.01.2021
+
+* Introduced new deeplinks `mewsAdultCount` and `mewsChildCount` to set initial occupancy.
+
 ## 29.11.2021
 
 * Changed domain from www.mews.li to api.mews.com

--- a/distributor-standalone/deeplinks.md
+++ b/distributor-standalone/deeplinks.md
@@ -21,6 +21,8 @@ Parameters can be combined and some have no visible effect unless they are used 
 | mewsVoucherCode | a voucher code | `E1A71167851A30043B12` |
 | mewsRoute | [mewsRoute](./deeplinks.md#parameter-mewsroute) | `rooms` for rooms step |
 | mewsRoom | opens with specified room selected \(`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`\) | `da394bbb-9685-4bb8-9547-ab7300915967` |
+| mewsAdultCount  | preselect room occupancy with initial adult count. [More details](./deeplinks.md#open-with-specific-initial-occupancy) | `3`                                    |
+| mewsChildCount  | preselect room occupancy with initial child count. [More details](./deeplinks.md#open-with-specific-initial-occupancy) | `1`                                    |
 | language | a language code \(`xx-YY`\) | `en-US` for U.S. English |
 | currency | a currency code \(`XXX`\) | `USD` for United States dollar |
 
@@ -74,4 +76,13 @@ https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?currency=E
 
 ```text
 https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?mewsRoute=hotels&mewsCityId=aaaa-bbbb-cccc-dddd
+```
+
+## Open with specific initial occupancy
+- Parameters can be combined or used separately.
+- When used - the Rates screen will preset the correct room occupancy.
+- Using it with combination of `mewsRoute=rates`, you can immediately open a specific room with a pre-selected occupancy.
+
+```text
+https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?mewsAdultCount=2&mewsChildCount=1
 ```

--- a/distributor-standalone/deeplinks.md
+++ b/distributor-standalone/deeplinks.md
@@ -21,8 +21,8 @@ Parameters can be combined and some have no visible effect unless they are used 
 | mewsVoucherCode | a voucher code | `E1A71167851A30043B12` |
 | mewsRoute | [mewsRoute](./deeplinks.md#parameter-mewsroute) | `rooms` for rooms step |
 | mewsRoom | opens with specified room selected \(`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`\) | `da394bbb-9685-4bb8-9547-ab7300915967` |
-| mewsAdultCount  | preselect room occupancy with initial adult count. [More details](./deeplinks.md#open-with-specific-initial-occupancy) | `3`                                    |
-| mewsChildCount  | preselect room occupancy with initial child count. [More details](./deeplinks.md#open-with-specific-initial-occupancy) | `1`                                    |
+| mewsAdultCount  | number of adults that should be selected by default | `3`                                    |
+| mewsChildCount  | number of children that should be selected by default | `1`                                    |
 | language | a language code \(`xx-YY`\) | `en-US` for U.S. English |
 | currency | a currency code \(`XXX`\) | `USD` for United States dollar |
 
@@ -76,13 +76,4 @@ https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?currency=E
 
 ```text
 https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?mewsRoute=hotels&mewsCityId=aaaa-bbbb-cccc-dddd
-```
-
-## Open with specific initial occupancy
-- Parameters can be combined or used separately.
-- When used - the Rates screen will preset the correct room occupancy.
-- Using it with combination of `mewsRoute=rates`, you can immediately open a specific room with a pre-selected occupancy.
-
-```text
-https://api.mews.com/distributor/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?mewsAdultCount=2&mewsChildCount=1
 ```

--- a/distributor-widget/changelog.md
+++ b/distributor-widget/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 17.01.2022
+
+* Introduced new methods on API object `setAdultCount` and `setChildCount` to set initial occupancy.
+
 ## 29.11.2021
 
 * Changed domain from www.mews.li to api.mews.com

--- a/distributor-widget/changelog.md
+++ b/distributor-widget/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 17.01.2022
+## 18.01.2022
 
-* Introduced new methods on API object `setAdultCount` and `setChildCount` to set initial occupancy.
+* Introduced new API methods to Distributor instance: [`setAdultCount`](./reference.md#setadultcount-adultcount) and [`setChildCount`](./reference.md#setchildcount-childcount).
 
 ## 29.11.2021
 

--- a/distributor-widget/reference.md
+++ b/distributor-widget/reference.md
@@ -104,6 +104,14 @@ distributor.setEndDate("2019-12-18")
 
 Sets a new voucher code value.
 
+#### setAdultCount\(adultCount\)
+
+* `adultCount` Type: `number` - number of adults for pre-selection of room occupancy and price adjustment.
+
+#### setChildCount\(childCount\)
+
+* `childCount` Type: `number` - number of children for pre-selection of room occupancy and price adjustment.
+
 #### disableTracking()
 
 Sets all [TrackingConsents](integrations.md#trackingconsents) to false.

--- a/distributor-widget/reference.md
+++ b/distributor-widget/reference.md
@@ -106,11 +106,15 @@ Sets a new voucher code value.
 
 #### setAdultCount\(adultCount\)
 
-* `adultCount` Type: `number` - number of adults for pre-selection of room occupancy and price adjustment.
+* `adultCount` Type: `number` - number of adults to set
+
+Sets the number of adults that should be selected by default. Space occupancy for adults on rate screen will be pre-filled according this value 
 
 #### setChildCount\(childCount\)
 
-* `childCount` Type: `number` - number of children for pre-selection of room occupancy and price adjustment.
+* `childCount` Type: `number` - number of children to set
+
+Sets the number of children that should be selected by default. Space occupancy for children on rate screen will be pre-filled according this value
 
 #### disableTracking()
 


### PR DESCRIPTION
#### Changelog notes 

```
* Introduced new deeplinks `mewsAdultCount` and `mewsChildCount` to set initial occupancy.
* Introduced new methods on API object `setAdultCount` and `setChildCount` to set initial occupancy.
```

#### Check during review

- [ ] JSON example extended.
  - [ ] New properties are added to the correct place in the JSON.
- [ ] New properties in the table are added to the correct place.
- [ ] Correct formatting:
  - [ ] Spacing is consistent between titles, sections, tables, ...
  - [ ] Correct JSON format - indentation.
- [ ] DateTime properties should always be defined in ISO format.
